### PR TITLE
feat: padroniza comunicação com API usando JSON

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-NOMINATIM_API: nominatim.api.url
-ORS_API: openroute.api.url
-ORS_KEY: openroute.api.key
-COUNTRY: yourcountryabbr
+NOMINATIM_API = 'https://nominatim.openstreetmap.org'
+ORS_API = 'https://api.openrouteservice.org/v2/directions/driving-car/geojson'
+ORS_KEY ='eyJvcmciOiI1YjNjZTM1OTc4NTExMTAwMDFjZjYyNDgiLCJpZCI6IjNkMzllM2RlM2MyNzRiN2JiNTU1ODI2YjI4ZmY3MDIzIiwiaCI6Im11cm11cjY0In0='
+COUNTRY = 'br'

--- a/assets/js/account/upload-file.js
+++ b/assets/js/account/upload-file.js
@@ -1,4 +1,7 @@
+import { apiRequest } from '../apis-config/http-client.js';
+
 const dropZone = document.querySelector('.upload-card__dropzone');
+const UPLOAD_ENDPOINT = dropZone?.dataset.uploadEndpoint || '/api/upload';
 
 dropZone.addEventListener('drop', dropHandler);
 
@@ -77,7 +80,7 @@ function displayImages(files) {
   img.src = '../public/icons/file-check.svg';
   img.alt = file.name;
   span.textContent = file.name;
-  sendButton.addEventListener('click', uploadFile(file));
+  sendButton.addEventListener('click', () => uploadFile(file));
   sendButton.textContent = 'Enviar';
 
   details.append(img, span);
@@ -100,20 +103,38 @@ fileInput.addEventListener('change', (e) => {
 });
 
 function uploadFile(file) {
-  let xhr = new XMLHttpRequest();
   const formData = new FormData();
   formData.append('file', file);
-  xhr.upload.addEventListener('progress', (e) => {
-    console.log(e);
-    if (e.lengthComputable) {
-      const percentage = Math.round((e.loaded / e.total) * 100);
-      const progressBar = document.querySelector('.upload-card__progress');
+  const progressBar = document.querySelector('.upload-card__progress');
+  const sendButton = document.querySelector('.upload-card__button');
+
+  if (sendButton) {
+    sendButton.disabled = true;
+  }
+
+  if (progressBar) {
+    progressBar.style.width = '30%';
+  }
+
+  apiRequest(UPLOAD_ENDPOINT, {
+    method: 'POST',
+    data: formData,
+    isUpload: true,
+  })
+    .then(() => {
       if (progressBar) {
-        progressBar.style.width = percentage + '%';
+        progressBar.style.width = '100%';
       }
-    }
-    console.log('oi');
-  });
-  xhr.open('POST', 'endpoit');
-  xhr.send(formData);
+    })
+    .catch((error) => {
+      console.error('Erro ao enviar arquivo:', error.message);
+      if (progressBar) {
+        progressBar.style.width = '0%';
+      }
+    })
+    .finally(() => {
+      if (sendButton) {
+        sendButton.disabled = false;
+      }
+    });
 }

--- a/assets/js/apis-config/apis.js
+++ b/assets/js/apis-config/apis.js
@@ -1,45 +1,148 @@
+import { apiRequest } from './http-client.js';
+
+let envConfigPromise = null;
+
+const DEFAULT_NOMINATIM_API = 'https://nominatim.openstreetmap.org';
+const DEFAULT_ENV_CONFIG = {
+  nominatimApi: DEFAULT_NOMINATIM_API,
+  orsApi: '',
+  orsKey: '',
+};
+
+function normalizeBaseUrl(value, fallback) {
+  if (typeof value !== 'string') return fallback;
+  const trimmedValue = value.trim();
+  if (!trimmedValue) return fallback;
+  return trimmedValue.replace(/\/+$/, '');
+}
+
+async function getEnvConfig() {
+  if (!envConfigPromise) {
+    envConfigPromise = apiRequest('http://localhost:3000/env', {
+      expectEnvelope: false,
+    })
+      .then(({ data }) => {
+        let parsedConfig = data;
+        if (typeof data === 'string') {
+          try {
+            parsedConfig = JSON.parse(data);
+          } catch (error) {
+            console.warn(
+              '[getEnvConfig] /env retornou string inválida. Usando fallback.',
+              error
+            );
+            parsedConfig = {};
+          }
+        }
+
+        if (!parsedConfig || typeof parsedConfig !== 'object') {
+          console.warn(
+            '[getEnvConfig] /env inválido (não é objeto). Usando fallback.'
+          );
+          parsedConfig = {};
+        }
+
+        return {
+          ...DEFAULT_ENV_CONFIG,
+          ...parsedConfig,
+          nominatimApi: normalizeBaseUrl(
+            parsedConfig.nominatimApi,
+            DEFAULT_NOMINATIM_API
+          ),
+        };
+      })
+      .catch((error) => {
+        console.error('[getEnvConfig] Falha ao carregar /env. Usando fallback.', error);
+        envConfigPromise = null;
+        return { ...DEFAULT_ENV_CONFIG };
+      });
+  }
+
+  try {
+    const config = await envConfigPromise;
+    return config && typeof config === 'object'
+      ? config
+      : { ...DEFAULT_ENV_CONFIG };
+  } catch (error) {
+    console.error('[getEnvConfig] Erro inesperado. Usando fallback.', error);
+    envConfigPromise = null;
+    return { ...DEFAULT_ENV_CONFIG };
+  }
+}
+
 export async function fetchNominatim(endpoint, params) {
-  let config = await fetch('http://localhost:3000/env').then((response) =>
-    response.json(),
-  );
+  try {
+    const safeEndpoint = typeof endpoint === 'string' ? endpoint.trim() : '';
+    if (!safeEndpoint) {
+      console.error('[fetchNominatim] endpoint ausente ou inválido.', { endpoint });
+      return [];
+    }
 
-  config = JSON.parse(config);
+    const config = await getEnvConfig();
+    const baseUrl = normalizeBaseUrl(config?.nominatimApi, DEFAULT_NOMINATIM_API);
+    const endpointPath = safeEndpoint.startsWith('/')
+      ? safeEndpoint
+      : `/${safeEndpoint}`;
 
-  const url = new URL(`${config.nominatimApi}${endpoint}`);
-  url.search = new URLSearchParams({
-    ...params,
-    countrycodes: 'br',
-    addressdetails: 1,
-    format: 'json',
-  });
-  const response = await fetch(url);
-  if (!response.ok) throw new Error('Erro Nominatim');
-  return await response.json();
+    let url;
+    try {
+      url = new URL(endpointPath, `${baseUrl}/`);
+    } catch (error) {
+      console.error('[fetchNominatim] URL inválida. Usando fallback padrão.', {
+        baseUrl,
+        endpoint: endpointPath,
+        error,
+      });
+      url = new URL(endpointPath, `${DEFAULT_NOMINATIM_API}/`);
+    }
+
+    url.search = new URLSearchParams({
+      ...(params || {}),
+      countrycodes: 'br',
+      addressdetails: 1,
+      format: 'json',
+    });
+
+    const { data } = await apiRequest(url.toString(), {
+      expectEnvelope: false,
+    });
+
+    return data ?? [];
+  } catch (error) {
+    console.error('[fetchNominatim] Falha ao buscar dados no Nominatim.', {
+      endpoint,
+      params,
+      error,
+    });
+    return [];
+  }
 }
 
 export async function fetchRoute(start, end) {
-  let config = await fetch('http://localhost:3000/env').then((response) =>
-    response.json(),
-  );
+  try {
+    const config = await getEnvConfig();
+    if (!config?.orsApi) {
+      console.error('[fetchRoute] orsApi ausente no /env.');
+      return null;
+    }
 
-  config = JSON.parse(config);
+    const { data } = await apiRequest(config.orsApi, {
+      method: 'POST',
+      headers: {
+        Authorization: config.orsKey,
+      },
+      data: {
+        coordinates: [
+          [start.lon, start.lat],
+          [end.lon, end.lat],
+        ],
+      },
+      expectEnvelope: false,
+    });
 
-  console.log(typeof config);
-  const response = await fetch(config.orsApi, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: config.orsKey,
-    },
-    body: JSON.stringify({
-      coordinates: [
-        [start.lon, start.lat],
-        [end.lon, end.lat],
-      ],
-    }),
-  });
-  console.log(config);
-  console.log(response);
-  if (!response.ok) throw new Error('Erro OpenRouteService');
-  return await response.json();
+    return data ?? null;
+  } catch (error) {
+    console.error('[fetchRoute] Falha ao buscar rota.', { start, end, error });
+    return null;
+  }
 }

--- a/assets/js/apis-config/http-client.js
+++ b/assets/js/apis-config/http-client.js
@@ -1,0 +1,106 @@
+function hasApiEnvelope(payload) {
+  return (
+    payload &&
+    typeof payload === 'object' &&
+    Object.prototype.hasOwnProperty.call(payload, 'success') &&
+    Object.prototype.hasOwnProperty.call(payload, 'data') &&
+    Object.prototype.hasOwnProperty.call(payload, 'message')
+  );
+}
+
+function normalizeApiEnvelope(payload, fallbackSuccess, fallbackMessage) {
+  if (hasApiEnvelope(payload)) {
+    return {
+      success: Boolean(payload.success),
+      data: payload.data,
+      message: typeof payload.message === 'string' ? payload.message : '',
+    };
+  }
+
+  return {
+    success: fallbackSuccess,
+    data: payload,
+    message: fallbackMessage || '',
+  };
+}
+
+async function parseResponseBody(response) {
+  const contentType = response.headers.get('content-type') || '';
+  if (!contentType.includes('application/json')) {
+    return null;
+  }
+
+  try {
+    return await response.json();
+  } catch {
+    return null;
+  }
+}
+
+export class ApiRequestError extends Error {
+  constructor(message, details = {}) {
+    super(message);
+    this.name = 'ApiRequestError';
+    this.status = details.status || 0;
+    this.response = details.response || null;
+  }
+}
+
+export async function apiRequest(url, options = {}) {
+  const {
+    method = 'GET',
+    data,
+    headers = {},
+    isUpload = false,
+    expectEnvelope = true,
+  } = options;
+
+  const requestHeaders = { ...headers };
+  const requestConfig = {
+    method,
+    headers: requestHeaders,
+  };
+
+  if (data !== undefined) {
+    if (isUpload) {
+      requestConfig.body = data;
+    } else {
+      requestHeaders['Content-Type'] = 'application/json';
+      requestConfig.body = JSON.stringify(data);
+    }
+  }
+
+  try {
+    const response = await fetch(url, requestConfig);
+    const parsedBody = await parseResponseBody(response);
+    const fallbackMessage = response.ok
+      ? ''
+      : `Erro HTTP ${response.status} ${response.statusText}`.trim();
+
+    const normalized = expectEnvelope
+      ? normalizeApiEnvelope(parsedBody, response.ok, fallbackMessage)
+      : {
+          success: response.ok,
+          data: parsedBody,
+          message: fallbackMessage,
+        };
+
+    if (!response.ok || !normalized.success) {
+      throw new ApiRequestError(
+        normalized.message || 'Falha na requisição da API',
+        {
+          status: response.status,
+          response: normalized,
+        },
+      );
+    }
+
+    return normalized;
+  } catch (error) {
+    if (error instanceof ApiRequestError) {
+      throw error;
+    }
+
+    throw new ApiRequestError('Erro de conexão com a API');
+  }
+}

--- a/pages/account.html
+++ b/pages/account.html
@@ -122,7 +122,7 @@
           </div>
           <div class="settings__panel" role="tabpanel" aria-hidden="false">
             <div class="upload-card">
-              <label class="upload-card__dropzone">
+              <label class="upload-card__dropzone" data-upload-endpoint="/api/upload">
                 <img src="/icons/file.svg" width="24" height="24" alt="" class="upload-card__icon" />
                 <p class="upload-card__label f-14">
                   Arraste e solte os arquivos ou clique para selecionar. Formatos Aceitos: .pdf, .jpg, .png
@@ -139,7 +139,7 @@
       </section>
     </main>
     <script type="module" src="/js/account/account.js"></script>
-    <script src="/js/account/upload-file.js"></script>
+    <script type="module" src="/js/account/upload-file.js"></script>
     <script src="/js/account/tabs.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Padronização das requisições do frontend para comunicação com a API utilizando JSON.

Alterações realizadas:
- Adição de headers Content-Type: application/json nas requisições
- Uso de JSON.stringify para envio de dados
- Padronização do tratamento das respostas da API
- Criação de helper para centralizar chamadas HTTP
- Ajuste de requisições de upload utilizando FormData

Objetivo:
Garantir consistência na comunicação com a API conforme padrão definido.